### PR TITLE
fix(media): generate Joli variations lazily on image request

### DIFF
--- a/config/packages/joli_media.yaml
+++ b/config/packages/joli_media.yaml
@@ -38,7 +38,12 @@ joli_media:
             # Cache for processed variations
             cache:
                 flysystem: "filesystem.cache.storage"
-                must_store_when_generating_url: true  # Generate variations immediately
+                # Variations are generated lazily on the first HTTP request to
+                # the cache URL. Setting this to true triggers Symfony\Process
+                # (cwebp/Imagine) synchronously during HTML rendering, which
+                # blows the 30s max_execution_time on cold caches with many
+                # responsive variations (1x/2x × JPG/WebP × variation/desktop).
+                must_store_when_generating_url: false
                 url_generator:
                     strategy: folder
                     path: /media/cache/


### PR DESCRIPTION
## Summary
- Flip `must_store_when_generating_url` to `false` in `config/packages/joli_media.yaml`
- Variation files now generate on the first HTTP request to the cache URL instead of synchronously during HTML render

## Why
Pi-staging was in `CrashLoopBackOff` on the new image (`eeed157`). Logs:
```
PHP Fatal error: Maximum execution time of 30 seconds exceeded in
/app/vendor/symfony/process/Pipes/AbstractPipes.php on line 200
```
Triggered on `GET /` and `GET /fr` → readiness/liveness probes timeout → pod restart loop.

`eeed157` reworked `Cover.html.twig` into `<picture><twig:joli:Source>` with a new `desktop` prop. Every page now requests up to 8 variations per image (`{1x,2x} × {JPG,WebP} × {variation,desktop}`). With `must_store_when_generating_url: true`, Joli synchronously spawned `cwebp`/Imagine (via `Symfony\Process`) for every missing variation during the Twig render. On ARM Pi 5 with a cold cache, the home page (Hero + N cards) blew through the 30s `max_execution_time`.

The Joli default (`false`) defers generation to the cache URL handler — the page returns fast, the browser fetches each variation in parallel, and each variation gets its own request budget.

## Tradeoff
First post-deploy visit will see slightly slower image loads (compression on first hit), then the PVC cache absorbs everything. The synchronous-rendering mode was strictly worse here: a single bottleneck on a cold cache could time out the whole page.

## Test plan
- [ ] CI build green
- [ ] Flux ImageUpdateAutomation rolls the new tag onto pi-staging
- [ ] New pod becomes Ready (no `Maximum execution time` errors)
- [ ] `https://staging.tinie-bakerie.com/fr` loads, images appear (may be slightly delayed on first load while WebP/2x variants generate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)